### PR TITLE
chore: clean up obsolete files and fix repository URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,8 @@ npm-debug.log*
 .DS_Store
 Thumbs.db
 
-# Documentation files
-freedcampdocs.html
-mcpdocs.md
+# Test logs
+*.log
 
 # Roo AI configuration files (prevent accidental commits)
 .roo/

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,23 @@
+# Product Overview
+
+## Freedcamp MCP Server
+
+A Model Context Protocol (MCP) server implementation that provides AI assistants with direct integration to Freedcamp task management platform. Enables creating, updating, listing, and deleting tasks through both traditional STDIO transport and modern HTTP transport methods.
+
+## Core Functionality
+
+- **Task Management**: Create, update, list, and delete tasks in Freedcamp projects
+- **Bulk Operations**: Support for multiple task operations in single requests
+- **Dual Transport**: STDIO transport for IDE integrations and HTTP transport for web/cloud deployments
+- **Authentication**: Secure API key and secret-based authentication with HMAC-SHA1 hashing
+- **Validation**: Comprehensive input validation using Zod schemas
+
+## Target Users
+
+- AI assistants and IDEs (Claude Desktop, Cursor, Roo)
+- Developers using MCP-compatible tools
+- Teams managing projects in Freedcamp who want AI-powered task management
+
+## Key Value Proposition
+
+Bridges the gap between AI assistants and Freedcamp project management, enabling natural language task management through conversational interfaces while maintaining full API compatibility and security standards.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,71 @@
+# Project Structure
+
+## Root Directory
+
+```
+freedcamp-mcp/
+├── src/                    # TypeScript source code
+├── dist/                   # Compiled JavaScript output
+├── tasks/                  # Task management and planning
+├── .kiro/                  # Kiro AI configuration
+├── .cursor/                # Cursor IDE configuration
+├── .husky/                 # Git hooks
+├── .github/                # GitHub workflows and templates
+└── node_modules/           # Dependencies
+```
+
+## Source Code Organization (`src/`)
+
+- **`server.ts`**: STDIO transport entry point with environment setup
+- **`http-server.ts`**: HTTP transport server with Express
+- **`mcpServer.ts`**: Core MCP server implementation and tool definitions
+- **`freedcamp.ts`**: Freedcamp API client and authentication logic
+- **`test-harness.ts`**: STDIO transport test suite
+- **`test-harness-http.ts`**: HTTP transport test suite
+
+## Configuration Files
+
+### Build & Runtime
+- **`package.json`**: Dependencies, scripts, and metadata
+- **`tsconfig.json`**: TypeScript compilation settings
+- **`Dockerfile`**: Container build instructions
+- **`docker-compose.yml`**: Multi-service orchestration
+
+### Development Tools
+- **`.gitignore`**: Version control exclusions
+- **`.env`**: Environment variables (not committed)
+- **`commitlint.config.cjs`**: Commit message standards
+
+### IDE Integration
+- **`.cursor/mcp.json`**: Cursor MCP server configuration
+- **`.kiro/steering/`**: AI assistant guidance documents
+
+## Task Management (`tasks/`)
+
+- **`tasks.json`**: Structured task definitions and dependencies
+- **`task_*.txt`**: Individual task descriptions and requirements
+
+## Architecture Principles
+
+### Separation of Concerns
+- **Transport Layer**: `server.ts`, `http-server.ts` handle protocol specifics
+- **Business Logic**: `mcpServer.ts` implements MCP tools and validation
+- **External API**: `freedcamp.ts` manages third-party integration
+- **Testing**: Separate test harnesses for each transport method
+
+### Configuration Management
+- Environment variables for all runtime configuration
+- No hardcoded credentials or URLs
+- Separate configs for development and production
+
+### Build Artifacts
+- Source maps disabled for production builds
+- Executable permissions set post-build
+- Clean separation between source and compiled code
+
+## File Naming Conventions
+
+- **kebab-case**: For files and directories
+- **camelCase**: For TypeScript variables and functions
+- **PascalCase**: For TypeScript classes and interfaces
+- **UPPER_CASE**: For environment variables and constants

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,71 @@
+# Technology Stack
+
+## Core Technologies
+
+- **Runtime**: Node.js >= 17.0.0
+- **Language**: TypeScript 5.3.3 with ES2022 target
+- **Module System**: ES Modules (type: "module")
+- **Build Tool**: TypeScript Compiler (tsc)
+
+## Key Dependencies
+
+- **@modelcontextprotocol/sdk**: MCP protocol implementation
+- **zod**: Runtime type validation and schema definition
+- **node-fetch**: HTTP client for API requests
+- **dotenv**: Environment variable management
+- **express**: HTTP server for REST transport
+
+## Development Tools
+
+- **husky**: Git hooks for code quality
+- **commitlint**: Conventional commit enforcement
+- **standard-version**: Automated versioning and changelog
+
+## Build System
+
+### Common Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Build TypeScript to JavaScript
+npm run build
+
+# Start STDIO transport server
+npm start
+
+# Start HTTP transport server
+npm run start:http
+
+# Development with watch mode
+npm run dev
+
+# Run comprehensive tests
+npm test
+npm run test:http
+
+# Environment-specific HTTP server
+npm run start:http:test  # Uses .env file
+```
+
+### Build Process
+
+1. TypeScript compilation: `src/` → `dist/`
+2. Post-build: Make executables chmod +x
+3. Output: Executable binaries in `dist/server.js` and `dist/http-server.js`
+
+## Architecture Patterns
+
+- **Modular Design**: Separate concerns (server, MCP logic, Freedcamp API)
+- **Transport Abstraction**: Support both STDIO and HTTP transports
+- **Schema-First**: Zod schemas define API contracts
+- **Environment-Based Config**: All credentials via environment variables
+- **Error-First**: Comprehensive error handling and validation
+
+## Deployment
+
+- **Docker**: Multi-stage build with Alpine Linux
+- **Docker Compose**: Production-ready orchestration
+- **Health Checks**: Built-in health monitoring endpoints
+- **Security**: Non-root user execution in containers

--- a/.npmignore
+++ b/.npmignore
@@ -4,12 +4,12 @@ test.js
 .env
 .git/
 .gitignore
-mcpdocs.md
-freedcampdocs.html
 .vscode/
 .idea/
 *.sublime-*
 .cursor/
+
+# Logs
 *.log
 npm-debug.log*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![npm version](https://img.shields.io/npm/v/freedcamp-mcp)](https://www.npmjs.com/package/freedcamp-mcp)
 [![license](https://img.shields.io/npm/l/freedcamp-mcp)](./LICENSE)
-[![build](https://github.com/gabeosx/freedmcpcamp/actions/workflows/ci.yml/badge.svg)](https://github.com/gabeosx/freedmcpcamp/actions/workflows/ci.yml)
+[![build](https://github.com/gabeosx/freedcamp-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/gabeosx/freedcamp-mcp/actions/workflows/ci.yml)
 [![downloads](https://img.shields.io/npm/dm/freedcamp-mcp)](https://www.npmjs.com/package/freedcamp-mcp)
 [![node](https://img.shields.io/node/v/freedcamp-mcp)](https://nodejs.org/)
-[![GitHub All Releases](https://img.shields.io/github/downloads/gabeosx/freedmcpcamp/total.svg)](https://github.com/gabeosx/freedmcpcamp/releases)
+[![GitHub All Releases](https://img.shields.io/github/downloads/gabeosx/freedcamp-mcp/total.svg)](https://github.com/gabeosx/freedcamp-mcp/releases)
 
 This is a Model Context Protocol (MCP) server implementation for Freedcamp task management. It provides tools for creating, updating, listing, and deleting tasks in Freedcamp projects with support for bulk operations.
 


### PR DESCRIPTION
- Remove obsolete development artifacts:
  - fix_commit.sh (unused git commit script)
  - freedcampdocs.html (large API docs file)
  - mcpdocs.md (duplicate MCP documentation)
  - test.log (generated test output)
- Update .gitignore and .npmignore to use pattern-based rules
- Fix GitHub repository URLs in README badges
- Add Kiro AI steering documents for better development guidance